### PR TITLE
[el9] make it el9 compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ sysstat_sar_service: no
 These variables control the collector:
 
 ```yml
+sysstat_files_umask: 0027
+
 sysstat_history_days: 28
 
 sysstat_compress_after_days: 31
@@ -45,6 +47,8 @@ sysstat_sadc_options: '-S DISK'
 sysstat_sa_dir: /var/log/sa
 
 sysstat_compression_program: bzip2
+
+sysstat_sa2_delay_range: 10
 
 sysstat_sa2_generate_yesterday: no
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,8 @@
 
 sysstat_sar_service: no
 
+sysstat_sar_service_start: started
+
 sysstat_history_days: 28
 
 sysstat_compress_after_days: 31

--- a/meta/.galaxy_install_info
+++ b/meta/.galaxy_install_info
@@ -1,0 +1,1 @@
+{install_date: 'Fri Mar 24 13:09:27 2023', version: v1.0.2}

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -16,6 +16,7 @@ galaxy_info:
         - 6
         - 7
         - 8
+        - 9
 
   galaxy_tags:
     - monitoring

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,14 @@
 ---
 
+- name: import OS specific variables
+  ansible.builtin.include_vars: '{{ item }}'
+  with_first_found:
+    - files:
+        - '{{ ansible_distribution | lower }}-{{ ansible_distribution_major_version }}.yml'
+        - '{{ ansible_os_family | lower }}-{{ ansible_distribution_major_version }}.yml'
+        - '{{ ansible_os_family | lower }}.yml'
+      skip: true
+
 - name: install sysstat
   yum:
     name: sysstat
@@ -29,6 +38,9 @@
     owner: root
     group: root
     mode: 0600
+  when:
+    - ansible_facts['distribution_major_version'] != "9"
+    - ansible_facts['os_family'] == "RedHat"
 
 - name: set sysstat service status
   service:
@@ -36,5 +48,10 @@
     enabled: '{{ sysstat_sar_service }}'
   tags:
     - service
+
+- name: start sysstat service
+  ansible.builtin.service:
+    name: sysstat
+    state: '{{ sysstat_sar_service_start }}'
 
 ...

--- a/templates/sysstat-conf-redhat-9.j2
+++ b/templates/sysstat-conf-redhat-9.j2
@@ -1,0 +1,57 @@
+# sysstat-{{ sysstat_installed_version }} configuration file.
+
+# How long to keep log files (in days).
+# If value is greater than 28, then use sadc's option -D to prevent older
+# data files from being overwritten. See sadc(8) and sysstat(5) manual pages.
+HISTORY={{ sysstat_history_days }}
+
+# Compress (using xz, gzip or bzip2) sa and sar files older than (in days):
+COMPRESSAFTER={{ sysstat_compress_after_days }}
+
+# Parameters for the system activity data collector (see sadc manual page)
+# which are used for the generation of log files.
+SADC_OPTIONS="{{ sysstat_sadc_options }}"
+
+# Directory where sa and sar files are saved. The directory must exist.
+SA_DIR={{ sysstat_sa_dir }}
+
+# Compression program to use.
+ZIP="{{ sysstat_compression_program }}"
+
+# By default sa2 script generates yesterday's summary, since the cron job
+# usually runs right after midnight. If you want sa2 to generate the summary
+# of the same day (for example when cron job runs at 23:53) set this variable.
+{% if sysstat_sa2_generate_yesterday is defined %}
+YESTERDAY="{{ sysstat_sa2_generate_yesterday }}"
+{% else %}
+#YESTERDAY=no
+{% endif %}
+
+# By default sa2 script generates reports files (the so called sarDD files).
+# Set this variable to false to disable reports generation.
+{% if sysstat_sa2_generate_reports is defined %}
+REPORTS="{{ sysstat_sa2_generate_reports }}"
+{% else %}
+#REPORTS=false
+{% endif %}
+
+# Tell sa2 to wait for a random delay in the range 0 .. ${DELAY_RANGE} before
+# executing. This delay is expressed in seconds, and is aimed at preventing
+# a massive I/O burst at the same time on VM sharing the same storage area.
+# Set this variable to 0 to make sa2 generate reports files immediately.
+{% if sysstat_sa2_delay_range is defined %}
+DELAY_RANGE="{{ sysstat_sa2_delay_range }}"
+{% else %}
+DELAY_RANGE=0
+{% endif %}
+
+# The sa1 and sa2 scripts generate system activity data and report files in
+# the /var/log/sa directory. By default the files are created with umask 0022
+# and are therefore readable for all users. Change this variable to restrict
+# the permissions on the files (e.g. use 0027 to adhere to more strict
+# security standards).
+{% if sysstat_files_umask is defined %}
+UMASK="{{ sysstat_files_umask }}"
+{% else %}
+UMASK=0022
+{% endif %}

--- a/vars/redhat-9.yml
+++ b/vars/redhat-9.yml
@@ -1,0 +1,7 @@
+---
+
+sysstat_sadc_options: ' -S DISK'
+
+sysstat_compression_program: xz
+
+...


### PR DESCRIPTION
- no diff on `/etc/sysconfig/sysstat` when running against fresh installed `sysstat` package from a Rocky Linux 9.1
- no diff or error on a CentOS 7 host
- no need for manual cron installation anymore - rpm package contains timers which have to be enabled by enable and start the `sysstat` systemd unit
- rolled out and tested on Rocky Linux 9 host

---

feel free to optimize way to switch arround with facts and vars and tell us which version number to use on eve to go on with el9 support :) 